### PR TITLE
feat: Add structured inputs input

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -158,6 +158,7 @@ jobs:
       - name: Test
         env:
           TF_ACC: "1"
+          TF_ACC_PROVIDER_NAMESPACE: terr4m
           TF_ACC_TERRAFORM_VERSION: ${{ matrix.tf_version }}
           TF_ACC_TERRAFORM_PATH: ${{ steps.tf.outputs.path }}
         run: go test -v -timeout 120m -cover ./...

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "go.testEnvVars": {
     "TF_ACC": "1",
+    "TF_ACC_PROVIDER_NAMESPACE": "terr4m",
+    "TF_ACC_TERRAFORM_PATH": "C:\\Users\\hipwells\\scoop\\apps\\terraform\\current\\terraform.exe",
   },
   "go.testTimeout": "1m",
 }

--- a/examples/data-sources/shell_script/data-source.tf
+++ b/examples/data-sources/shell_script/data-source.tf
@@ -1,22 +1,23 @@
 data "shell_script" "example" {
-  environment = {
-    "TF_VERSION_COUNT" = "3"
+  inputs = {
+    version_count = 3
   }
-
   os_commands = {
     default = {
       read = {
         command = <<-EOF
           set -euo pipefail
-          curl -s https://endoflife.date/api/terraform.json | jq -rc --argjson count "$${TF_VERSION_COUNT}" '[sort_by(.releaseDate) | reverse | .[0:$count] | .[].latest]' > "$${TF_SCRIPT_OUTPUT}"
+          version_count="$(echo "$${TF_SCRIPT_INPUTS}" | jq -r '.version_count')"
+          curl -s https://endoflife.date/api/terraform.json | jq -rc --argjson count "$${version_count}" '[sort_by(.releaseDate) | reverse | .[0:$count] | .[].latest]' > "$${TF_SCRIPT_OUTPUT}"
         EOF
       }
     }
     windows = {
       read = {
         command = <<-EOF
+          $inputs = $env:TF_SCRIPT_INPUTS | ConvertFrom-Json
           $response = Invoke-RestMethod -Uri "https://endoflife.date/api/terraform.json"
-          $sorted = $response | Sort-Object releaseDate -Descending | Select-Object -First $env:TF_VERSION_COUNT
+          $sorted = $response | Sort-Object releaseDate -Descending | Select-Object -First $inputs.version_count
           $latest = $sorted | ForEach-Object { $_.latest }
           $latest | ConvertTo-Json -Compress | Out-File -FilePath $env:TF_SCRIPT_OUTPUT -Encoding utf8
         EOF

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
+	LifecycleEnv            string = "TF_SCRIPT_LIFECYCLE"
+	InputsEnv               string = "TF_SCRIPT_INPUTS"
+	StateOutputEnv          string = "TF_SCRIPT_STATE_OUTPUT"
 	ScriptOutputFilePathEnv string = "TF_SCRIPT_OUTPUT"
 	ScriptErrorFilePathEnv  string = "TF_SCRIPT_ERROR"
-	StateOutputEnv          string = "TF_SCRIPT_STATE_OUTPUT"
-	LifecycleEnv            string = "TF_SCRIPT_LIFECYCLE"
 )
 
 type TFLifecycle string
@@ -29,7 +30,7 @@ const (
 )
 
 // runCommand runs a shell script and returns the output.
-func runCommand(ctx context.Context, providerData *ShellProviderData, tfInterpreter types.List, tfEnvironment types.Map, tfWorkingDirectory, tfCommand types.String, lifecycle TFLifecycle, stateOutput any, readJSON bool) (any, diag.Diagnostics) {
+func runCommand(ctx context.Context, providerData *ShellProviderData, tfInterpreter types.List, tfEnvironment types.Map, tfWorkingDirectory, tfCommand types.String, lifecycle TFLifecycle, inputs, stateOutput any, readJSON bool) (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var interpreter []string
@@ -69,6 +70,16 @@ func runCommand(ctx context.Context, providerData *ShellProviderData, tfInterpre
 	environment[LifecycleEnv] = string(lifecycle)
 	environment[ScriptOutputFilePathEnv] = outFilePath
 	environment[ScriptErrorFilePathEnv] = errorFilePath
+
+	if inputs != nil {
+		by, err := json.Marshal(inputs)
+		if err != nil {
+			diags.AddError("Failed to marshal inputs.", err.Error())
+			return nil, diags
+		}
+
+		environment[InputsEnv] = string(by)
+	}
 
 	if stateOutput != nil {
 		by, err := json.Marshal(stateOutput)

--- a/internal/tfdynamic/encode.go
+++ b/internal/tfdynamic/encode.go
@@ -14,7 +14,7 @@ func EncodeDynamic(ctx context.Context, d types.Dynamic) (any, error) {
 		return nil, fmt.Errorf("underlying value is unknown")
 	}
 
-	if d.IsUnderlyingValueNull() {
+	if d.IsNull() || d.IsUnderlyingValueNull() {
 		return nil, nil
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Description

This PR adds an `inputs` input to allow structured inputs to the scripts.

Fixes #38

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made

- Add support for passing script values via `inputs`.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/terr4m/terraform-provider-github/blob/main/CONTRIBUTING.md) document
- [ ] My code follows the idiomatic Go coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have used table tests where appropriate
- [ ] I have used google/go-cmp for test comparisons
- [ ] Any dependent changes have been merged and published

## Breaking Changes

If this is a breaking change, please describe the impact and migration path for existing users:

## Additional Notes

Add any other context about the pull request here.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
