### PR TITLE
feat!: compute output_drift for shell_script resource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -87,8 +87,6 @@ resource "shell_script" "example" {
       }
     }
   }
-
-  output_drift = false
 }
 ```
 

--- a/docs/resources/script.md
+++ b/docs/resources/script.md
@@ -166,8 +166,6 @@ resource "shell_script" "example" {
       }
     }
   }
-
-  output_drift = false
 }
 ```
 
@@ -177,7 +175,6 @@ resource "shell_script" "example" {
 ### Required
 
 - `os_commands` (Attributes Map) A map of commands to run as part of the Terraform lifecycle where the map key is the `GOOS` value or `default`; `default` must be provided. (see [below for nested schema](#nestedatt--os_commands))
-- `output_drift` (Boolean) This is used by the provider to manage the output state and must always be set to false.
 
 ### Optional
 
@@ -190,6 +187,7 @@ resource "shell_script" "example" {
 ### Read-Only
 
 - `output` (Dynamic) The output of the script as a structured type; this can be accessed in the read, update and delete commands as JSON via the `TF_SCRIPT_STATE_OUTPUT` environment variable.
+- `output_drift` (Boolean) If the output has drifted and needs reconciling.
 
 <a id="nestedatt--os_commands"></a>
 ### Nested Schema for `os_commands`

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -62,6 +62,4 @@ resource "shell_script" "example" {
       }
     }
   }
-
-  output_drift = false
 }

--- a/examples/resources/shell_script/resource.tf
+++ b/examples/resources/shell_script/resource.tf
@@ -112,6 +112,4 @@ resource "shell_script" "example" {
       }
     }
   }
-
-  output_drift = false
 }

--- a/internal/provider/script.go
+++ b/internal/provider/script.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -197,12 +196,9 @@ func (r *ScriptResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Computed:            true,
 			},
 			"output_drift": schema.BoolAttribute{
-				Description:         "This is used by the provider to manage the output state and must always be set to false.",
-				MarkdownDescription: "This is used by the provider to manage the output state and must always be set to false.",
-				Required:            true,
-				Validators: []validator.Bool{
-					boolvalidator.Equals(false),
-				},
+				Description:         "If the output has drifted and needs reconciling.",
+				MarkdownDescription: "If the output has drifted and needs reconciling.",
+				Computed:            true,
 			},
 			"triggers": schema.DynamicAttribute{
 				Description:         "Allows specifying values that trigger resource replacement when changed.",
@@ -289,7 +285,6 @@ func (r *ScriptResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 
 		plan.Output = types.DynamicUnknown()
 	} else {
-
 		timeout, diags := plan.Timeouts.Read(ctx, r.providerData.DefaultTimeouts.Read)
 		if resp.Diagnostics.Append(diags...); resp.Diagnostics.HasError() {
 			return
@@ -379,6 +374,7 @@ func (r *ScriptResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 	plan.Output = out
+	plan.OutputDrift = types.BoolValue(false)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/internal/provider/script_test.go
+++ b/internal/provider/script_test.go
@@ -58,7 +58,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `, cmd),
 					ConfigStateChecks: []statecheck.StateCheck{
@@ -150,7 +149,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ConfigStateChecks: []statecheck.StateCheck{
@@ -219,7 +217,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ConfigStateChecks: []statecheck.StateCheck{
@@ -294,7 +291,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ConfigStateChecks: []statecheck.StateCheck{
@@ -363,7 +359,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ConfigStateChecks: []statecheck.StateCheck{
@@ -459,7 +454,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 
@@ -558,7 +552,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 
@@ -641,7 +634,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ConfigStateChecks: []statecheck.StateCheck{
@@ -755,7 +747,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `
 
@@ -897,7 +888,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `, file)
 
@@ -984,7 +974,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `
 
@@ -1008,51 +997,6 @@ resource "shell_script" "test" {
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue("shell_script.test", tfjsonpath.New("output"), knownvalue.ObjectExact(map[string]knownvalue.Check{"run": knownvalue.Bool(true)})),
 					},
-				},
-			},
-		})
-	})
-
-	t.Run("error_no_output_drift", func(t *testing.T) {
-		t.Parallel()
-
-		cmd := `printf '{"run": true}' > "$${TF_SCRIPT_OUTPUT}"`
-		if runtime.GOOS == "windows" {
-			cmd = `'{"run": true}' | Out-File -FilePath $env:TF_SCRIPT_OUTPUT -Encoding utf8`
-		}
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { testAccPreCheck(t) },
-			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: fmt.Sprintf(`
-resource "shell_script" "test" {
-  os_commands = {
-    default = {
-      create = {
-        command = <<-EOF
-          %s
-        EOF
-      }
-      read = {
-        command = <<-EOF
-          %[1]s
-        EOF
-      }
-      update = {
-        command = <<-EOF
-          %[1]s
-        EOF
-      }
-      delete = {
-        command = ""
-      }
-    }
-  }
-}
-`, cmd),
-					ExpectError: regexp.MustCompile(`Missing required argument`),
 				},
 			},
 		})
@@ -1093,7 +1037,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ExpectError: regexp.MustCompile(`Default commands are required`),
@@ -1128,7 +1071,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ExpectError: regexp.MustCompile(`Failed to read output file`),
@@ -1163,7 +1105,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ExpectError: regexp.MustCompile(`Command failed with exit code: 1`),
@@ -1236,7 +1177,6 @@ resource "shell_script" "test" {
       }
     }
   }
-  output_drift = false
 }
 `,
 					ExpectError: regexp.MustCompile(`my-error`),


### PR DESCRIPTION
## Description <!-- rumdl-disable-line MD041 -->

The `output_drift` attribute on the `shell_script` resource is now computed.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made

- Made the `output_drift` attribute on the `shell_script` resource computed

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/terr4m/terraform-provider-github/blob/main/CONTRIBUTING.md) document
- [x] My code follows the idiomatic Go coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have used table tests where appropriate
- [x] I have used google/go-cmp for test comparisons
- [x] Any dependent changes have been merged and published

## Breaking Changes

This change requires the removal of `output_drift` from the `shell_script` resource configuration.

## Additional Notes

n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
