### PR TITLE
Fix provider-level environment being overwritten by resource environment

### DIFF
--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 
@@ -56,14 +57,17 @@ func runCommand(ctx context.Context, providerData *ShellProviderData, tfInterpre
 	}
 
 	environment := map[string]string{}
-	for k, v := range providerData.Environment {
-		environment[k] = v
-	}
+	maps.Copy(environment, providerData.Environment)
 
 	if !tfEnvironment.IsNull() {
-		if diags.Append(tfEnvironment.ElementsAs(ctx, &environment, false)...); diags.HasError() {
+		// ElementsAs replaces the target map via reflection (reflect.MakeMapWithSize
+		// in the plugin framework), so decode into a temporary map first and then
+		// merge to preserve the provider-level environment entries copied above.
+		resourceEnv := map[string]string{}
+		if diags.Append(tfEnvironment.ElementsAs(ctx, &resourceEnv, false)...); diags.HasError() {
 			return res, diags
 		}
+		maps.Copy(environment, resourceEnv)
 	}
 
 	outFilePath, err := shell.GetOutFilePath()


### PR DESCRIPTION
## Problem

When both the provider block and a resource define `environment`, the resource-level environment completely replaces the provider-level environment instead of merging with it.

```hcl
provider "shell" {
  environment = {
    AWS_PROFILE = var.aws_profile  # ← gets silently dropped
  }
}

resource "shell_script" "example" {
  environment = {
    TABLE_NAME = "my-table"  # ← only this survives
  }
  # ...
}
```

The `AWS_PROFILE` set at the provider level is never passed to the command.

### Root cause

In `runCommand()` (`internal/provider/common.go`), the provider-level environment is correctly copied into the `environment` map first. But then `ElementsAs()` is called to decode the resource-level environment directly into the same map. Under the hood, the Terraform plugin framework's `ElementsAs` uses `reflect.MakeMapWithSize` which creates a brand new map, replacing the target rather than merging into it.

## Solution

Decode the resource-level environment into a temporary map, then merge it into the existing environment map that already contains the provider-level entries. This preserves the documented behavior where resource environment merges with (and can override) provider environment.

## Test plan

- Configured `provider "shell" { environment = { AWS_PROFILE = "..." } }` with a resource that also sets `environment`
- Verified the provider-level `AWS_PROFILE` is now correctly passed through to the command alongside the resource-level variables
- Verified resource-level values still override provider-level values when both set the same key